### PR TITLE
Add check to verify user only has 1 monitor

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -99,7 +99,7 @@ export default class FullscreenToNewWorkspace extends Extension {
             {
             const manager = win.get_display().get_workspace_manager();
             const current = manager.get_active_workspace_index();
-            if (this._mutterSettings.get_boolean('workspaces-only-on-primary'))
+            if (this._mutterSettings.get_boolean('workspaces-only-on-primary') || global.get_display().get_n_monitors() == 1)
                 {
                 const mPrimary=win.get_display().get_primary_monitor();
                 // Only primary monitor is relevant, others don't have multiple workspaces
@@ -204,7 +204,7 @@ export default class FullscreenToNewWorkspace extends Extension {
             {
             const manager = win.get_display().get_workspace_manager();
             const current = manager.get_active_workspace_index();
-            if (this._mutterSettings.get_boolean('workspaces-only-on-primary'))
+            if (this._mutterSettings.get_boolean('workspaces-only-on-primary') || global.get_display().get_n_monitors() == 1)
                 {
                 const mPrimary=win.get_display().get_primary_monitor();
                 // Only primary monitor is relevant, others don't have multiple workspaces


### PR DESCRIPTION
I recently moved and went from two monitors to a single monitor. This extension was acting unexpectedly and felt to be broken because it would open apps on the last workspace, effectively shifting everything to the end. I discovered it was caused by my previous settings from when I had a dual monitor setup 

I believe this matches the expected behavior better without forcing the user to update their settings. 